### PR TITLE
Fix inherited values for modellist output.

### DIFF
--- a/R/profitRemakeModelList.R
+++ b/R/profitRemakeModelList.R
@@ -134,6 +134,9 @@ profitRemakeModellist = function(parm, modellist, tofit, tolog=NULL, intervals=N
   for (i in inheritIDs) {
     parmmod[i] = parmmod[i - 1]
   }
+  # And make sure the inherited values are propagated to modellistnew as well
+  # (although the solution here is a bit circular and maybe not ideal)
+  modellistnew = relist(parmmod, modellistnew)
   
   # Apply offset before unlogging to avoid problems with offset[4]
   if(!is.null(offset)){


### PR DESCRIPTION
Inherited values are those where tofit = NA. They are supposed to be inherited from the immediately preceding values (parent values). Now the problem was that if those parent values changed while applying the intervals and constraints, then the inherited values did not change accordingly in the $modellist output. They were already correct in the $parm output (I fixed that previously by re-inheriting the values after applying intervals and constraints; now I also propagate that change through to the new modellist so everything is consistent again).